### PR TITLE
Get the build working on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ notifications:
   email: false
 before_script:
   - export PATH=$PATH:~/.cargo/bin
+  # If this is a linux environment then point /user/bin/c++ to clang
+  # This is extremely hacky.
+  - if [ "$(readlink $(which c++))" == "/etc/alternatives/c++" ]; then sudo rm /usr/bin/c++; sudo ln -s /usr/local/clang-5.0.0/bin/clang++ /usr/bin/c++; fi
+  - c++ --version
 script:
   - cargo build --verbose
   - cargo test --verbose

--- a/build.rs
+++ b/build.rs
@@ -6,10 +6,12 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-	Build::new()
+	let mut builder = Build::new();
+
+	builder
 		.cpp(true)
 		// https://github.com/facebook/yoga/blob/7f44ec512e7d150b7312336ed7908ac86441b4cc/BUCK#L13
-		.flag("-std=c++11")
+		.flag("-std=c++1y")
 		// https://github.com/facebook/yoga/blob/7f44ec512e7d150b7312336ed7908ac86441b4cc/yoga_defs.bzl#L28
 		.flag("-fno-omit-frame-pointer")
 		.flag("-fexceptions")
@@ -22,10 +24,14 @@ fn main() {
 		.file("src/c/YGEnums.cpp")
 		.file("src/c/YGNode.cpp")
 		.file("src/c/YGNodePrint.cpp")
-		.file("src/c/Yoga.cpp")
-		.compile("libyoga.a");
+		.file("src/c/Yoga.cpp");
+
+	println!("Compiler is {:?}", builder.get_compiler());
+
+	builder.compile("libyoga.a");
 
 	let bindings = bindgen::Builder::default()
+		.clang_arg("-std=c++11")
 		.no_unstable_rust()
 		.no_convert_floats()
 		.enable_cxx_namespaces()


### PR DESCRIPTION
This is a pretty dirty change, I don't really like it. My brain is done for now though, maybe you can find a cleaner way.

Here's what I've learned:

* The OS X environment's `c++` symlink points to clang++
* The Linux environment's `c++` symlink points to g++
* If you explicitly specify `clang++` as the compiler, binggen will generate a `--target=x86_64-apple-darwin` flag for clang. This makes clang completely unable to find basic header files like `#include <array>` and I didn't really investigate why
* If you leave it as `c++`, bindgen doesn't generate that target flag, and things work fine for OS X
* So on Linux, my goal was to get `c++` to point to `clang++` instead of `g++`
* Theoretically we could have figured out the right flags or something to pass to `g++`, but I just wanted to use clang and call it a day
* So this PR is a sneaky way of pointing `c++` to `clang++`, but only on Linux because the path to Clang on OS X is different

Please. If you have something better I'd be happy to change to something less hacky and brittle.